### PR TITLE
Change Carbon version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.4.0",
-        "nesbot/Carbon": "1.9.*",
+        "nesbot/Carbon": "~1.9",
         "illuminate/database": "~4.2.6",
         "illuminate/encryption": "~4.2.6",
         "illuminate/events": "~4.2.6",


### PR DESCRIPTION
I would like to update the versioning for Carbon because the specific version of this package leads to some conflicts with composer installation. This is especially prevalent since the laravel framework itself requires Carbon like this: `"nesbot/carbon": "~1.0"`

This PR shouldn't actually cause any problems since Carbon doesn't follow semantic versioning and updates in what would be major versions in semantic.

Please also merge this into at leas the 0.5 branch since this is my actual use of the package, but I am creating against the master because of its general relevance.