### PR TITLE
changed watson/validation require to ~1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "illuminate/hashing": "~5.0.0",
         "illuminate/support": "~5.0.0",
         "illuminate/validation": "~5.0.0",
-        "watson/validating": "dev-master"
+        "watson/validating": "~1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.1.*",


### PR DESCRIPTION
the dev-master was throwing the following error for me:
- Installation request for esensi/model 0.5.* -> satisfiable by esensi/model[0.5.0]. 
- esensi/model 0.5.0 requires watson/validating dev-master -> no matching package found.
