### PR TITLE
Fix for morphClass and morphMap support

### DIFF
--- a/src/Traits/RelatingModelTrait.php
+++ b/src/Traits/RelatingModelTrait.php
@@ -289,6 +289,8 @@ trait RelatingModelTrait
         // we will pass in the appropriate values so that it behaves as expected.
         else
         {
+            $class = $this->getActualClassNameForMorph($class);
+            
             $instance = new $class;
 
             return new MorphTo(


### PR DESCRIPTION
morphMap was added in https://github.com/laravel/framework/pull/9891 and allows you to map morphClass to the correct classes where previously laravel would throw a class not found error trying to access morphTo. Essentially saving you the trouble of [various work arounds](http://stackoverflow.com/questions/27866020/laravel-returning-the-namespaced-owner-of-a-polymorphic-relation/27993113).

Example:
```
Relation::morphMap([
    'product'    => \App\Models\Product::class,
    'whitelabel' => \App\Models\WhiteLabel::class,
]);
```
or assuming table name:
```
Relation::morphMap([
    \App\Models\Product::class,
    \App\Models\WhiteLabel::class,
]);
```

I also noticed a few changes to the backtrace that haven't made their way into esensi/model yet:
https://github.com/laravel/framework/blob/5.2/src/Illuminate/Database/Eloquent/Model.php#L878

Should we clean it up to match?