### PR TITLE
Fix for morphClass and morphMap support

### DIFF
--- a/src/Traits/RelatingModelTrait.php
+++ b/src/Traits/RelatingModelTrait.php
@@ -289,8 +289,12 @@ trait RelatingModelTrait
         // we will pass in the appropriate values so that it behaves as expected.
         else
         {
+            if( method_exists($this, 'getActualClassNameForMorph') ) 
+            {
+                $class = $this->getActualClassNameForMorph($class);
+            }
             $instance = new $class;
-
+            
             return new MorphTo(
                 with($instance)->newQuery(), $this, $id, $instance->getKeyName(), $type, $name
             );


### PR DESCRIPTION
Based on #27, additionally checks if `getActualClassNameForMorph` method exists, so it should be safe to use with older Laravel 5.1 versions.