### PR TITLE
Fix Issue #30

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -14,7 +14,7 @@ return Config::create()
         'not_operator_with_space' => true,
         'ordered_imports' => true,
         'phpdoc_order' => true,
-        'phpdoc_var_to_type' => true,
+        'phpdoc_type_to_var' => true,
         'psr0' => false,
         'short_array_syntax' => true,
         'unalign_double_arrow' => false,

--- a/src/Contracts/SoftDeletingModelInterface.php
+++ b/src/Contracts/SoftDeletingModelInterface.php
@@ -14,11 +14,6 @@ namespace Esensi\Model\Contracts;
 interface SoftDeletingModelInterface
 {
     /**
-     * Boot the soft deleting trait for a model.
-     */
-    public static function bootSoftDeletingTrait();
-
-    /**
      * Force a hard delete on a soft deleted model.
      */
     public function forceDelete();

--- a/src/Contracts/SoftDeletingModelInterface.php
+++ b/src/Contracts/SoftDeletingModelInterface.php
@@ -38,20 +38,6 @@ interface SoftDeletingModelInterface
     public function trashed();
 
     /**
-     * Get a new query builder that includes soft deletes.
-     *
-     * @return Illuminate\Database\Eloquent\Builder|static
-     */
-    public static function withTrashed();
-
-    /**
-     * Get a new query builder that only includes soft deletes.
-     *
-     * @return Illuminate\Database\Eloquent\Builder|static
-     */
-    public static function onlyTrashed();
-
-    /**
      * Register a restoring model event with the dispatcher.
      *
      * @param Closure|string $callback

--- a/src/Model.php
+++ b/src/Model.php
@@ -93,14 +93,14 @@ abstract class Model extends Eloquent implements
     /**
      * The attributes that should be mutated to dates.
      *
-     * @type array
+     * @var array
      */
     protected $dates = [];
 
     /**
      * The default rules that the model will validate against.
      *
-     * @type array
+     * @var array
      */
     protected $rules = [];
 
@@ -109,7 +109,7 @@ abstract class Model extends Eloquent implements
      *
      * @deprecated watson/validating 0.10.9
      *
-     * @type array
+     * @var array
      */
     protected $rulesets = [];
 
@@ -117,42 +117,42 @@ abstract class Model extends Eloquent implements
      * The attributes to encrypt when set and
      * decrypt when gotten.
      *
-     * @type array
+     * @var array
      */
     protected $encryptable = [];
 
     /**
      * The attributes to hash before saving.
      *
-     * @type array
+     * @var array
      */
     protected $hashable = [];
 
     /**
      * Attributes to cast to a different type.
      *
-     * @type array
+     * @var array
      */
     protected $jugglable = [];
 
     /**
      * The attributes to purge before saving.
      *
-     * @type array
+     * @var array
      */
     protected $purgeable = [];
 
     /**
      * Relationships that the model should set up.
      *
-     * @type array
+     * @var array
      */
     protected $relationships = [];
 
     /**
      * Extra attributes to be added to pivot relationships.
      *
-     * @type array
+     * @var array
      */
     protected $relationshipPivots = [];
 

--- a/src/Traits/EncryptingModelTrait.php
+++ b/src/Traits/EncryptingModelTrait.php
@@ -21,14 +21,14 @@ trait EncryptingModelTrait
     /**
      * Whether the model is encrypting or not.
      *
-     * @type bool
+     * @var bool
      */
     protected $encrypting = true;
 
     /**
      * The Encrypter to use for encryption.
      *
-     * @type Illuminate\Encryption\Encrypter
+     * @var Illuminate\Encryption\Encrypter
      */
     protected $encrypter;
 

--- a/src/Traits/HashingModelTrait.php
+++ b/src/Traits/HashingModelTrait.php
@@ -21,14 +21,14 @@ trait HashingModelTrait
     /**
      * Whether the model is hashing or not.
      *
-     * @type bool
+     * @var bool
      */
     protected $hashing = true;
 
     /**
      * The Hasher to use for hashing.
      *
-     * @type Illuminate\Contracts\Hashing\Hasher
+     * @var Illuminate\Contracts\Hashing\Hasher
      */
     protected $hasher;
 
@@ -162,7 +162,7 @@ trait HashingModelTrait
             return false;
         }
 
-        $info = password_get_info($this->attributes[ $attribute ]);
+        $info = password_get_info($this->attributes[$attribute]);
 
         return (bool) ($info['algo'] !== 0);
     }
@@ -213,11 +213,11 @@ trait HashingModelTrait
     public function setHashingAttribute($attribute, $value)
     {
         // Set the value which is presumably plain text
-        $this->attributes[ $attribute ] = $value;
+        $this->attributes[$attribute] = $value;
 
         // Do the hashing if it needs it
         if ( ! empty($value) && ($this->isDirty($attribute) || ! $this->isHashed($attribute))) {
-            $this->attributes[ $attribute ] = $this->hash($value);
+            $this->attributes[$attribute] = $this->hash($value);
         }
     }
 

--- a/src/Traits/JugglingModelTrait.php
+++ b/src/Traits/JugglingModelTrait.php
@@ -21,7 +21,7 @@ trait JugglingModelTrait
     /**
      * Whether the model is type juggling attributes or not.
      *
-     * @type bool
+     * @var bool
      */
     protected $juggling = true;
 
@@ -53,7 +53,7 @@ trait JugglingModelTrait
         parent::__set($key, $value);
 
         // Dynamically set the juggled value
-        $this->setDynamicJuggle($key, $this->attribute[ $key ]);
+        $this->setDynamicJuggle($key, $this->attribute[$key]);
     }
 
     /**
@@ -320,7 +320,7 @@ trait JugglingModelTrait
     {
         $jugglable = $this->getJugglable();
 
-        return $jugglable[ $attribute ];
+        return $jugglable[$attribute];
     }
 
     /**
@@ -331,8 +331,8 @@ trait JugglingModelTrait
         // Iterate the juggable fields, and if the field is present
         // cast the attribute and replace within the attributes array.
         foreach ($this->getJugglable() as $attribute => $type) {
-            if (isset($this->attributes[ $attribute ])) {
-                $this->juggleAttribute($attribute, $this->attributes[ $attribute ]);
+            if (isset($this->attributes[$attribute])) {
+                $this->juggleAttribute($attribute, $this->attributes[$attribute]);
             }
         }
     }
@@ -347,7 +347,7 @@ trait JugglingModelTrait
     public function juggleAttribute($attribute, $value)
     {
         $type = $this->getJuggleType($attribute);
-        $this->attributes[ $attribute ] = $this->juggle($value, $type);
+        $this->attributes[$attribute] = $this->juggle($value, $type);
     }
 
     /**

--- a/src/Traits/PurgingModelTrait.php
+++ b/src/Traits/PurgingModelTrait.php
@@ -20,7 +20,7 @@ trait PurgingModelTrait
     /**
      * Whether the model is purging or not.
      *
-     * @type bool
+     * @var bool
      */
     protected $purging = true;
 

--- a/src/Traits/RelatingModelTrait.php
+++ b/src/Traits/RelatingModelTrait.php
@@ -120,7 +120,7 @@ trait RelatingModelTrait
             throw $exception;
         }
 
-        return $this->relationships[ $name ];
+        return $this->relationships[$name];
     }
 
     /**
@@ -132,7 +132,7 @@ trait RelatingModelTrait
      */
     public function getPivotAttributes($name)
     {
-        return $this->relationshipPivots[ $name ] ?: [];
+        return $this->relationshipPivots[$name] ?: [];
     }
 
     /**

--- a/src/Traits/SoftDeletingModelTrait.php
+++ b/src/Traits/SoftDeletingModelTrait.php
@@ -28,7 +28,7 @@ trait SoftDeletingModelTrait
      * We want to boot our own observer so we stub out this
      * boot method. This renders this function void.
      */
-    public static function bootSoftDeletingTrait()
+    public static function bootSoftDeletes()
     {
     }
 

--- a/tests/EncryptingModelTraitTest.php
+++ b/tests/EncryptingModelTraitTest.php
@@ -506,7 +506,7 @@ class ModelEncryptingStub extends Model
      * The attributes to encrypt when set and
      * decrypt when gotten.
      *
-     * @type array
+     * @var array
      */
     protected $encryptable = ['foo'];
 

--- a/tests/HashingModelTraitTest.php
+++ b/tests/HashingModelTraitTest.php
@@ -516,7 +516,7 @@ class ModelHashingStub extends Model
     /**
      * The attributes to hash before saving.
      *
-     * @type array
+     * @var array
      */
     protected $hashable = ['foo'];
 

--- a/tests/JugglingModelTraitTest.php
+++ b/tests/JugglingModelTraitTest.php
@@ -569,14 +569,14 @@ class ModelJugglingStub extends Model
     /**
      * Indicates if the model exists.
      *
-     * @type bool
+     * @var bool
      */
     public $exists = false;
 
     /**
      * The attributes to type juggle.
      *
-     * @type array
+     * @var array
      */
     protected $jugglable = [
         'myString'    => 'string',
@@ -597,7 +597,7 @@ class ModelJugglingStub extends Model
      * in the tests to set the attributes in the object.
      * Make sure the keys align with $jugglabe property on this stub.
      *
-     * @type array
+     * @var array
      */
     public $tmpAttributes = [
         'myString'    => 'Hello world',

--- a/tests/PurgingModelTraitTest.php
+++ b/tests/PurgingModelTraitTest.php
@@ -401,7 +401,7 @@ class ModelPurgingStub extends Model
     /**
      * The attributes to purge before saving.
      *
-     * @type array
+     * @var array
      */
     protected $purgeable = ['foo'];
 }

--- a/tests/RelatingModelTraitTest.php
+++ b/tests/RelatingModelTraitTest.php
@@ -169,14 +169,14 @@ class ModelRelatingStub extends Model
     /**
      * Indicates if the model exists.
      *
-     * @type bool
+     * @var bool
      */
     public $exists = false;
 
     /**
      * Relationships that the model should set up.
      *
-     * @type array
+     * @var array
      */
     protected $relationships = [
 
@@ -199,7 +199,7 @@ class ModelRelatingStub extends Model
     /**
      * Extra attributes to be added to pivot relationships.
      *
-     * @type array
+     * @var array
      */
     protected $relationshipPivots = [
 
@@ -215,7 +215,7 @@ class FooModelStub extends Model
     /**
      * Relationships that the model should set up.
      *
-     * @type array
+     * @var array
      */
     protected $relationships = [
 

--- a/tests/SoftModelTest.php
+++ b/tests/SoftModelTest.php
@@ -95,7 +95,7 @@ class SoftModelStub extends SoftModel
     /**
      * The attributes that should be mutated to dates.
      *
-     * @type array
+     * @var array
      */
     protected $dates = ['foo'];
 }


### PR DESCRIPTION
This is a fix for Issue #30.

Additionally we may want to look into [this line](https://github.com/esensi/core/blob/0.6/src/Traits/CruddableRepositoryTrait.php#L119) to make it more robust. We don't want to assume the model is a SoftDeletingModelInterface but of course that would suffice. And really we want to know if softDeletes() is available but at one point Laravel dropped that method so I think that's why we looked for the restore(). That and we want to ensure that a soft-deleted model can be restored. @stygiansabyss @diegocaprioli thoughts?