### PR TITLE
Update the allowed random compat version to make compatible with Laravel 5.3

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -17,9 +17,10 @@ return Config::create()
         'phpdoc_type_to_var' => true,
         'psr0' => false,
         'short_array_syntax' => true,
-        'binary_operator_spaces' => false,
+        'unalign_double_arrow' => false,
+        'unalign_equals' => false,
     ])
-    ->setFinder(
+    ->finder(
         Finder::create()
             ->in(__DIR__.'/src')
             ->in(__DIR__.'/tests')

--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,12 @@
         "illuminate/hashing": "~5.1",
         "illuminate/support": "~5.1",
         "illuminate/validation": "~5.1",
-        "paragonie/random_compat": "~1.4|~2.0",
+        "paragonie/random_compat": "^1|^2",
         "symfony/polyfill-php56": "~1.1",
         "watson/validating": "~1.0.0 || ~2.0.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "2.0.*@dev",
+        "friendsofphp/php-cs-fixer": "2.0.0-alpha",
         "fzaninotto/faker": "~1.4",
         "mockery/mockery": "0.9.*",
         "phpunit/phpunit": "~4.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "illuminate/hashing": "~5.1",
         "illuminate/support": "~5.1",
         "illuminate/validation": "~5.1",
-        "paragonie/random_compat": "~1.1",
+        "paragonie/random_compat": "~1.4|~2.0",
         "symfony/polyfill-php56": "~1.1",
         "watson/validating": "~1.0.0 || ~2.0.0"
     },


### PR DESCRIPTION
Update allowed random [compat version](https://github.com/laravel/framework/pull/13882/files#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780L28) in `composer.json` to make `esensi/model` compatible with Laravel **5.3**.

Works and tested on Laravel **5.2** too.