### PR TITLE
Remove redundant paragonie/random_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "illuminate/hashing": "^8.0|^9.0",
         "illuminate/support": "^8.0|^9.0",
         "illuminate/validation": "^8.0|^9.0",
-        "paragonie/random_compat": "^8.0|^9.0",
         "symfony/polyfill-php81": "^1.23",
         "watson/validating": "^6.1"
 


### PR DESCRIPTION
This package depends on `paragonie/random_compat: ^8.0|^9.0`, but also `php: ^8.2`. Since `random_bytes` and `random_int` were added in PHP 7.0, the dependency on `paragonie/random_compat` seems redundant?