### PR TITLE
Remove redundant symfony/polyfill-php81 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "illuminate/support": "^8.0|^9.0",
         "illuminate/validation": "^8.0|^9.0",
         "paragonie/random_compat": "^8.0|^9.0",
-        "symfony/polyfill-php81": "^1.23",
         "watson/validating": "^6.1"
 
     },


### PR DESCRIPTION
This package depends on `symfony/polyfill-php81`, but also `php: ^8.2`, so the polyfill requirement doesn't seem necessary anymore?